### PR TITLE
updating gulp-sass depdency and updating FDA proxy to use HTTPS

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -67,7 +67,6 @@
     <script src="filters/cut/cut.js"></script>
     <script src="directives/related-recalls/related-recalls.directive.js"></script>
     <script src="directives/event-charts/event-charts-chart.directive.js"></script>
-
     <!-- endinject -->
 
     <!-- endbuild -->

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "apidoc": "^0.12.3",
     "del": "^1.1.1",
     "errorhandler": "^1.3.3",
+    "generator-bangular": "^0.11.2",
     "gulp": "^3.8.10",
     "gulp-angular-filesort": "^1.1.1",
     "gulp-angular-templatecache": "^1.5.0",
@@ -27,7 +28,7 @@
     "gulp-protractor": "^1.0.0",
     "gulp-replace": "^0.5.2",
     "gulp-rev-all": "0.8.18",
-    "gulp-sass": "^1.3.2",
+    "gulp-sass": "^2.2.0",
     "gulp-uglify": "^1.1.0",
     "gulp-usemin": "^0.3.11",
     "gulp-util": "^3.0.2",
@@ -43,8 +44,7 @@
     "should": "^6.0.1",
     "streamqueue": "^0.1.2",
     "supertest": "^0.15.0",
-    "yo": "^1.4.7",
-    "generator-bangular": "^0.11.2"
+    "yo": "^1.4.7"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/server/api/countEvents.js
+++ b/server/api/countEvents.js
@@ -35,7 +35,7 @@ module.exports = function (req, res) {
       if (config.openFdaApiKey) {
         queryWithKey += '&api_key=' + config.openFdaApiKey;
       }
-      superagent.get('http://api.fda.gov/drug/event.json?limit=1&search=' + queryWithKey)
+      superagent.get('https://api.fda.gov/drug/event.json?limit=1&search=' + queryWithKey)
         .end(function (err, res) {
           if (err) {
             if (err.status === 404 || err.status === 400) {

--- a/server/api/fdaProxy.js
+++ b/server/api/fdaProxy.js
@@ -11,7 +11,7 @@ var url = require('url');
  * 2) Instruct the client to cache all responses for 1 day (except for 429 TOO MANY REQUEST responses)
  */
 
-module.exports = proxy('http://api.fda.gov', {
+module.exports = proxy('https://api.fda.gov', {
   decorateRequest: function (req) {
 
     // IF the server has been configured with an OpenFDA API key, attach the key to each proxied request.

--- a/server/api/fdaProxy.js
+++ b/server/api/fdaProxy.js
@@ -13,7 +13,7 @@ var url = require('url');
 
 module.exports = proxy('https://api.fda.gov', {
   decorateRequest: function (req) {
-    console.log(req.headers);
+    req.headers = {}; // don't forward our headers!
 
     // IF the server has been configured with an OpenFDA API key, attach the key to each proxied request.
     if (config.openFdaApiKey) {

--- a/server/api/fdaProxy.js
+++ b/server/api/fdaProxy.js
@@ -13,6 +13,7 @@ var url = require('url');
 
 module.exports = proxy('https://api.fda.gov', {
   decorateRequest: function (req) {
+    console.log(req.headers);
 
     // IF the server has been configured with an OpenFDA API key, attach the key to each proxied request.
     if (config.openFdaApiKey) {


### PR DESCRIPTION
The FDA API has terminated support for the HTTP. This updates the app to use HTTPS instead.
